### PR TITLE
autoprof: use name of main package, not module

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -1,0 +1,51 @@
+package autoprof_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/rhysh/autoprof"
+)
+
+func TestCurrentArchiveMeta(t *testing.T) {
+	ctx := context.Background()
+
+	cmd := exec.CommandContext(ctx, "go", "run", "./internal/test")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("go run: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr:\n%s", stderr.Bytes())
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(stdout.Bytes()), int64(stdout.Len()))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+
+	mbuf, err := fs.ReadFile(zr, "meta")
+	if err != nil {
+		t.Fatalf("ReadFile(\"meta\"): %v", err)
+	}
+
+	var meta autoprof.ArchiveMeta
+	err = json.Unmarshal(mbuf, &meta)
+	if err != nil {
+		t.Fatalf("json.Unmarshal(\"meta\"): %v", err)
+	}
+
+	if !strings.HasSuffix(meta.Main, "/internal/test") {
+		t.Errorf("meta.Main: incorrect package name %q", meta.Main)
+	}
+}

--- a/internal/test/main.go
+++ b/internal/test/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/rhysh/autoprof"
+)
+
+func main() {
+	ctx := context.Background()
+
+	meta := autoprof.CurrentArchiveMeta()
+	opt := &autoprof.ArchiveOptions{}
+	buf := new(bytes.Buffer)
+
+	err := autoprof.NewZipCollector(buf, meta, opt).Run(ctx)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Printf("%s", buf.Bytes())
+	}
+}

--- a/meta.go
+++ b/meta.go
@@ -37,7 +37,7 @@ func generateArchiveMeta() (*ArchiveMeta, error) {
 	}
 
 	if info, ok := debug.ReadBuildInfo(); ok {
-		meta.Main = info.Main.Path
+		meta.Main = info.Path
 		meta.Revision = info.Main.Version
 	}
 


### PR DESCRIPTION
Data bundles include the name of the app that generated the bundle. The correct name to use is the full path of the command itself, not of the module which contains the command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
